### PR TITLE
feature : event info img sizes

### DIFF
--- a/app/_components/common/skeleton-list/SkeletonList.module.scss
+++ b/app/_components/common/skeleton-list/SkeletonList.module.scss
@@ -3,15 +3,16 @@
 
   &--carousel {
     display: flex;
-    gap: 30px;
+    gap: 10px;
     overflow-x: hidden;
     padding-left: 30px;
   }
 
   &--board {
-    display: flex;
-    flex-wrap: wrap;
-    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 20px;
+    width: 100%;
     overflow-y: scroll;
     scrollbar-width: none;
 

--- a/app/_components/common/skeleton-list/SkeletonList.module.scss
+++ b/app/_components/common/skeleton-list/SkeletonList.module.scss
@@ -15,6 +15,8 @@
     width: 100%;
     overflow-y: scroll;
     scrollbar-width: none;
+    padding: 0px 20px;
+    box-sizing: border-box;
 
     &::-webkit-scrollbar {
       display: none;

--- a/app/_components/common/skeleton-list/SkeletonList.tsx
+++ b/app/_components/common/skeleton-list/SkeletonList.tsx
@@ -30,17 +30,17 @@ const SkeletonList = (props: SkeletonListProps) => {
                 'card--column--board': listType === 'board',
               })}
             >
-              <Skeleton width={200} height={200} borderRadius={5} />
-              <Skeleton width={200} />
-              <Skeleton width={200} />
+              <Skeleton width={160} height={200} borderRadius={5} />
+              <Skeleton width={160} />
+              <Skeleton width={160} />
             </div>
           ) : (
             <div className={cx('card--row')}>
               <Skeleton width={125} height={125} borderRadius={5} />
 
               <div className={cx('infos')}>
-                <Skeleton width={100} />
-                <Skeleton width={100} />
+                <Skeleton width={200} />
+                <Skeleton width={200} />
               </div>
             </div>
           )}

--- a/app/_components/features/eventInfo/EventInfo.module.scss
+++ b/app/_components/features/eventInfo/EventInfo.module.scss
@@ -19,10 +19,12 @@
     .img-wrapper {
       box-sizing: border-box;
       width: 100%;
+      max-width: 475px;
       max-height: 570px;
       position: relative;
       overflow: hidden;
       aspect-ratio: 3/4;
+      margin: 0 auto;
 
       .main-image {
         object-fit: cover;
@@ -139,10 +141,12 @@
         flex-direction: column;
         gap: 36px;
         width: 100%;
+        align-items: center;
 
         .content-img-wrapper {
           position: relative;
           width: 100%;
+          max-width: 475px;
           height: 570px;
           aspect-ratio: 3/4;
           overflow: hidden;
@@ -168,6 +172,7 @@
     height: 100%;
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 32px;
   }
 }

--- a/app/_components/features/eventInfo/EventInfo.tsx
+++ b/app/_components/features/eventInfo/EventInfo.tsx
@@ -277,6 +277,8 @@ const EventInfo = (props: EventInfoProps) => {
                 list={nearEvents}
               />
             )}
+
+            <div className={cx('spacer')} />
           </div>
         </div>
       )}

--- a/app/_components/features/main/PopularList/PopularList.tsx
+++ b/app/_components/features/main/PopularList/PopularList.tsx
@@ -54,7 +54,7 @@ const PopularList = (props: PopularListProps) => {
       </div>
 
       {isLoading ? (
-        <SkeletonList listType="carousel" cardType="column" length={3} />
+        <SkeletonList listType="carousel" cardType="column" length={6} />
       ) : (
         <div className={cx('list-wrapper')}>
           <Swiper

--- a/app/_components/features/searchList/SearchList/SearchList.module.scss
+++ b/app/_components/features/searchList/SearchList/SearchList.module.scss
@@ -22,6 +22,8 @@
     width: 100%;
     overflow-y: scroll;
     scrollbar-width: none;
+    padding: 0px 20px;
+    box-sizing: border-box;
 
     &::-webkit-scrollbar {
       display: none;

--- a/app/_components/features/searchList/SearchList/SearchList.tsx
+++ b/app/_components/features/searchList/SearchList/SearchList.tsx
@@ -48,7 +48,7 @@ const SearchList = (props: SearchListProps) => {
       </div>
 
       {isFetching ? (
-        <SkeletonList listType="board" cardType="column" length={8} />
+        <SkeletonList listType="board" cardType="column" length={10} />
       ) : (
         <>
           {list && list.length > 0 ? (

--- a/app/_components/ui/chip/Chip.module.scss
+++ b/app/_components/ui/chip/Chip.module.scss
@@ -10,6 +10,10 @@
   padding: 12px 16px;
   box-sizing: border-box;
 
+  .text-wrapper {
+    flex-shrink: 0;
+  }
+
   img {
     filter: invert(1);
   }

--- a/app/_components/ui/chip/Chip.tsx
+++ b/app/_components/ui/chip/Chip.tsx
@@ -44,7 +44,7 @@ const Chip = (props: ChipProps) => {
       onClick={onClick}
       {...rest}
     >
-      {children}
+      <div className={cx('text-wrapper')}>{children}</div>
 
       {suffixIcon && (
         <div

--- a/app/_styles/globals.scss
+++ b/app/_styles/globals.scss
@@ -20,7 +20,7 @@ $navigation-height: 103px;
     .content {
       position: relative;
       width: 100%;
-      height: calc(100 * var(--vh) - #{$header-height} - #{$navigation-height});
+      height: calc(var(--vh) * 100 - #{$header-height} - #{$navigation-height});
       margin-top: $header-height;
     }
 
@@ -31,7 +31,7 @@ $navigation-height: 103px;
 
   &.exhibition.lists {
     .content {
-      height: 100%;
+      height: calc(var(--vh) * 100 - #{$header-height} - #{$navigation-height});
     }
   }
 }


### PR DESCRIPTION
ccb3e219ab8fa33cf624d1f8ac784cd2b3f3ab59
- event info 의 이미지들의 최대 가로 길이를 고정합니다.

93854645b6a6632c4caf9e0aea83b02df5a4b138
- event info 에서 rendering 이슈를 해결하기 위해 div 태그를 추가합니다.

d007c19253888189fd862c8a188b782baf2160f0
- searchlist에 padding 을 추가합니다.

9d6986be0a816e6e9e9995804ccd6c0cb8dfb971
- 모바일 화면에서 chip 이 무너지지 않게 스타일을 조정합니다.

b971f11a968d3c8bc55a35328ba08423dae598c0
- 전시 페이지의 높이를 수정합니다.